### PR TITLE
Update to TLDetector to publish correctly TL points from a predefined topic

### DIFF
--- a/ros/src/tl_detector/CMakeLists.txt
+++ b/ros/src/tl_detector/CMakeLists.txt
@@ -24,7 +24,7 @@ find_package(catkin REQUIRED COMPONENTS
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed
 ## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
-# catkin_python_setup()
+catkin_python_setup()
 
 ################################################
 ## Declare ROS messages, services and actions ##
@@ -200,4 +200,6 @@ include_directories(
 # endif()
 
 ## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)
+if(CATKIN_ENABLE_TESTING)
+    catkin_add_nosetests(test_tl_detector.py)
+endif()

--- a/ros/src/tl_detector/setup.py
+++ b/ros/src/tl_detector/setup.py
@@ -1,0 +1,12 @@
+## ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+# fetch values from package.xml
+setup_args = generate_distutils_setup(
+    packages=['tl_detector'],
+    package_dir={'': ''},
+)
+
+setup(**setup_args)

--- a/ros/src/tl_detector/test_tl_detector.py
+++ b/ros/src/tl_detector/test_tl_detector.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+
+# ## in order to run tests first time follow the procedure below (despite how weird it is)
+
+# catkin_make
+# source devel/setup.bash
+# touch src/tl_detector/CMakeLists.txt
+# catkin_make run_tests
+
+# ## touch is used to trigger CMake execution once again after the first build and is required due to some bug in Catkin
+# https://github.com/ros/catkin/issues/974
+# Every next run of tests can be triggered by
+# catkin_make run_tests
+# or just simple
+# python -m unittest discover -s src/tl_detector
+
+PKG = 'tl_detector'
+import unittest
+
+from tl_detector import TLDetector
+from styx_msgs.msg import Lane, Waypoint
+from styx_msgs.msg import TrafficLightArray, TrafficLight
+from geometry_msgs.msg import Pose
+
+N_WPS = 10 # number of waypoints for test
+
+
+class TestTlDetector(unittest.TestCase):
+
+    def setUp(self):
+        self.tld = TLDetector(init_without_ros=True)
+
+        base_wps = Lane()
+
+        for pt in range(N_WPS):
+            wp = Waypoint()
+            wp.pose.pose.position.x = pt
+            wp.pose.pose.position.y = pt
+            base_wps.waypoints.append(wp)
+
+        self.tld.waypoints_cb(base_wps)
+
+        lights = TrafficLightArray()
+        l_arr = [[1.0, 1.0, 0], [2.0, 2.2, 4], [3.0, 2.5, 1], [6.0, 6.0, 0] ]
+        for l in l_arr:
+            tl = TrafficLight()
+            tl.state = l[2]
+            tl.pose.pose.position.x = l[0]
+            tl.pose.pose.position.y = l[1]
+            lights.lights.append(tl)
+        self.tld.traffic_cb(lights)
+
+    def test_wp_cb(self):
+        self.assertEqual(len(self.tld.waypoints.waypoints), N_WPS)
+        self.assertEqual(len(self.tld.waypoints_2d), N_WPS)
+        self.assertTrue(self.tld.waypoint_tree)
+
+    def test_get_closest_wp(self):
+        p = Pose()
+        p.position.x = 3.0
+        p.position.y = 3.0
+
+        idx = self.tld.get_closest_waypoint(p)
+
+        self.assertEqual(idx, 3)
+
+    def test_get_closest_wp_nearby(self):
+        p = Pose()
+        p.position.x = 3.0
+        p.position.y = 2.5
+
+        idx = self.tld.get_closest_waypoint(p)
+
+        self.assertEqual(idx, 3)
+
+    def test_get_closest_wp_nearby_above(self):
+        p = Pose()
+        p.position.x = 3.0
+        p.position.y = 3.5
+
+        idx = self.tld.get_closest_waypoint(p)
+
+        self.assertEqual(idx, 4)
+
+# traffic_cb tests
+    def test_get_tl(self):
+        self.assertEqual(self.tld.lights_red_2d, [1, 6]) #corresponding waypoint ids for each red traffic light
+
+    def test_get_tl_no_red(self):
+        p = Pose()
+        p.position.x = 3.0
+        p.position.y = 3.0
+
+        self.tld.lights_red_2d = []
+        # self.tld.lights = []
+
+        idx = self.tld.get_closest_light(p)
+
+        self.assertEqual(idx, (-1, 4))
+
+    def test_get_tl_wp_1ahead(self):
+        p = Pose()
+        p.position.x = 3.0
+        p.position.y = 3.0
+
+        idx = self.tld.get_closest_light(p)
+
+        self.assertEqual(idx, (6, 0))
+
+    def test_get_tl_wp_2ahead(self):
+        p = Pose()
+        p.position.x = 0.0
+        p.position.y = 0.1
+
+        idx = self.tld.get_closest_light(p)
+
+        self.assertEqual(idx, (1, 0))
+
+    def test_get_tl_wp_loop(self):
+        p = Pose()
+        p.position.x = 10.0
+        p.position.y = 10.0
+
+        idx = self.tld.get_closest_light(p)
+
+        self.assertEqual(idx, (1, 0))
+
+
+
+if __name__ == '__main__':
+   import rosunit
+   rosunit.unitrun(PKG, 'test_tl_detector', TestTlDetector)

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -12,46 +12,62 @@ from light_classification.tl_classifier import TLClassifier
 import tf
 import cv2
 import yaml
+from scipy.spatial import KDTree
+import numpy as np
 
 STATE_COUNT_THRESHOLD = 3
 
 class TLDetector(object):
-    def __init__(self):
-        rospy.init_node('tl_detector')
+
+    def __init__(self, init_without_ros=False):
+        """
+        :param init_without_ros: in case class has to run in test environment and we don't want ros sub/pub to fail
+        """
 
         self.pose = None
         self.waypoints = None
+        self.waypoints_2d = None
+        self.waypoint_tree = None
+
         self.camera_image = None
+
         self.lights = []
-
-        sub1 = rospy.Subscriber('/current_pose', PoseStamped, self.pose_cb)
-        sub2 = rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb)
-
-        '''
-        /vehicle/traffic_lights provides you with the location of the traffic light in 3D map space and
-        helps you acquire an accurate ground truth data source for the traffic light
-        classifier by sending the current color state of all traffic lights in the
-        simulator. When testing on the vehicle, the color state will not be available. You'll need to
-        rely on the position of the light and the camera image to predict it.
-        '''
-        sub3 = rospy.Subscriber('/vehicle/traffic_lights', TrafficLightArray, self.traffic_cb)
-        sub6 = rospy.Subscriber('/image_color', Image, self.image_cb)
+        self.lights_red_2d = [] # [waypoint_idx, ... ] array of waypoints associated with the red light
 
         config_string = rospy.get_param("/traffic_light_config")
         self.config = yaml.load(config_string)
 
-        self.upcoming_red_light_pub = rospy.Publisher('/traffic_waypoint', Int32, queue_size=1)
-
         self.bridge = CvBridge()
         self.light_classifier = TLClassifier()
-        self.listener = tf.TransformListener()
+        # self.listener = tf.TransformListener()
 
         self.state = TrafficLight.UNKNOWN
         self.last_state = TrafficLight.UNKNOWN
         self.last_wp = -1
         self.state_count = 0
 
-        rospy.spin()
+        # for test purposes in order to reduce amount of published data
+        self.last_tl_pub_time = 0
+
+        if not init_without_ros:
+            rospy.init_node('tl_detector')
+
+            rospy.Subscriber('/current_pose', PoseStamped, self.pose_cb)
+            rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb)
+
+            '''
+            /vehicle/traffic_lights provides you with the location of the traffic light in 3D map space and
+            helps you acquire an accurate ground truth data source for the traffic light
+            classifier by sending the current color state of all traffic lights in the
+            simulator. When testing on the vehicle, the color state will not be available. You'll need to
+            rely on the position of the light and the camera image to predict it.
+            '''
+            rospy.Subscriber('/vehicle/traffic_lights', TrafficLightArray, self.traffic_cb)
+            rospy.Subscriber('/image_color', Image, self.image_cb)
+
+            self.upcoming_red_light_pub = rospy.Publisher('/traffic_waypoint', Int32, queue_size=1)
+
+            rospy.spin()
 
     def pose_cb(self, msg):
         self.pose = msg
@@ -59,8 +75,29 @@ class TLDetector(object):
     def waypoints_cb(self, waypoints):
         self.waypoints = waypoints
 
+        if not self.waypoints_2d:
+            self.waypoints_2d = [[waypoint.pose.pose.position.x, waypoint.pose.pose.position.y] for waypoint in
+                                 waypoints.waypoints]
+            self.waypoint_tree = KDTree(self.waypoints_2d)
+
     def traffic_cb(self, msg):
+
+        red_wps_idx = []
+        for l in msg.lights:
+            if l.state == TrafficLight.RED:
+                l_wp_idx = self.get_closest_waypoint_xy(l.pose.pose.position.x, l.pose.pose.position.y)
+                red_wps_idx.append(l_wp_idx)
+        red_wps_idx.sort()
+
         self.lights = msg.lights
+        self.lights_red_2d = red_wps_idx
+
+        # for testing without proper detector TODO: remove
+        # rospy.logwarn("Update TL point 101 wps={}, pose={}".format(self.waypoints is not None, self.pose is not None))
+        if self.waypoints and self.pose and self.last_tl_pub_time < rospy.get_rostime().secs:
+            self.last_tl_pub_time = rospy.get_rostime().secs
+            # rospy.logwarn("Update TL point")
+            self.image_cb(None)
 
     def image_cb(self, msg):
         """Identifies red lights in the incoming camera image and publishes the index
@@ -73,6 +110,8 @@ class TLDetector(object):
         self.has_image = True
         self.camera_image = msg
         light_wp, state = self.process_traffic_lights()
+        # if state == 0:
+        # rospy.logwarn("Traffic light: pt=%s, state=%s", light_wp, state)
 
         '''
         Publish upcoming red lights at camera frequency.
@@ -91,57 +130,6 @@ class TLDetector(object):
         else:
             self.upcoming_red_light_pub.publish(Int32(self.last_wp))
         self.state_count += 1
-
-    def get_closest_waypoint(self, pose):
-        """Identifies the closest path waypoint to the given position
-            https://en.wikipedia.org/wiki/Closest_pair_of_points_problem
-        Args:
-            pose (Pose): position to match a waypoint to
-
-        Returns:
-            int: index of the closest waypoint in self.waypoints
-
-        """
-        min_idx = -1
-        min_dist = sys.float_info.max
-        for idx, wp in enumerate(self.waypoints.waypoints):
-            dist = distance(pose, wp.pose.pose)
-            if dist < min_dist:
-                min_dist = dist
-                min_idx = idx
-        return min_idx
-
-    def get_closest_light(self, pose):
-        """Identifies the closest traffic light to the given position.
-
-        Args:
-            post (Pose): position to match a light to
-
-        int: index of the closest light in self.lights.
-        """
-        if not self.lights:
-            return -1
-
-        min_idx = -1
-        min_dist = sys.float_info.max
-        for idx, light in enumerate(self.lights):
-            dist = distance(pose, light.pose.pose)
-            if dist < min_dist:
-                min_dist = dist
-                min_idx = idx
-        return min_idx
-
-    def distance(wp1, wp2):
-        """Computes the xy distance between two positions.
-
-        Args:
-            wp1 (Pose): first positions.
-            wp2 (Pose): second positions.
-
-        Returns:
-            float64: distance between the two waypoints
-        """
-        return math.sqrt((wp1.x - wp2.x) ** 2 + (wp1.y - wp2.y) ** 2)
 
     def get_light_state(self, light):
         """Determines the current color of the traffic light
@@ -172,32 +160,81 @@ class TLDetector(object):
             location and color
 
         Returns:
-            int: index of waypoint closes to the upcoming stop line for a traffic light (-1 if none exists)
+            int: index of waypoint closest to the upcoming stop line for a traffic light (-1 if none exists)
             int: ID of traffic light color (specified in styx_msgs/TrafficLight)
 
         """
         light = None
 
         # List of positions that correspond to the line to stop in front of for a given intersection
-        stop_line_positions = self.config['stop_line_positions']
-        if(self.pose):
-            car_position = self.get_closest_waypoint(self.pose.pose)
+        # stop_line_positions = self.config['stop_line_positions']
+        # if(self.pose):
+        #     car_position = self.get_closest_waypoint(self.pose.pose)
 
         # Find the closest visible traffic light (if one exists)
         #TODO maybe only execute this if a light was actually seen in a camera image
-        closest_light_idx = self.get_closest_light(self.pose.pose)
-        if closest_light_idx > 0:
-            light = self.lights[closest_light_idx]
+        return self.get_closest_light(self.pose.pose)
 
-        if light:
-            state = self.get_light_state(light)
-            light_wp = self.get_closest_waypoint(light.pose.pose)
-            if car_position < light_wp:
-                return light_wp, state
+    def get_closest_light(self, pose):
+        """Identifies the closest traffic light to the given position.
+
+        Args:
+            post (Pose): position to match a light to
+
+        int: index of the closest light in self.lights.
+        """
+        if not self.lights :
             return -1, TrafficLight.UNKNOWN
-        self.waypoints = None
-        return -1, TrafficLight.UNKNOWN
 
+        x = pose.position.x
+        y = pose.position.y
+        wp_idx = self.get_closest_waypoint_xy(x, y)
+
+        for l_idx in self.lights_red_2d:
+            if l_idx > wp_idx:
+                return l_idx, TrafficLight.RED
+
+        if len(self.lights_red_2d):  # waypoint is further than last light - let's loop
+            return self.lights_red_2d[0], TrafficLight.RED
+        else:
+            return -1, TrafficLight.UNKNOWN
+
+    # Waypoint updater imported
+
+    def get_closest_waypoint(self, pose):
+        x = pose.position.x
+        y = pose.position.y
+        return self.get_closest_waypoint_xy(x, y)
+
+    def get_closest_waypoint_xy(self, x, y):
+        return self.get_closest_array_idx_xy(self.waypoints_2d, self.waypoint_tree, x, y)
+
+    @staticmethod
+    def get_closest_array_idx_xy(points_array, points_tree, x, y):
+        closest_idx = points_tree.query([x, y], 1)[1]
+
+        # Check if closest is ahead or behind vehicle/traffic_lights`
+        closest_cord = points_array[closest_idx]
+        prev_cord = points_array[closest_idx - 1]
+
+        # Hyperplane through closest_cord
+        cl_vect = np.array(closest_cord)
+        prev_vect = np.array(prev_cord)
+        pos_vect = np.array([x, y])
+        val = np.dot(cl_vect - prev_vect, pos_vect - cl_vect)
+        if val > 0:
+            closest_idx = (closest_idx + 1) % len(points_array)
+
+        return closest_idx
+
+    @staticmethod
+    def distance(waypoints, idx1, idx2):
+        dist = 0
+        dl = lambda a, b: math.sqrt((a.x - b.x) ** 2 + (a.y - b.y) ** 2 + (a.z - b.z) ** 2)
+        for i in range(idx1, idx2 + 1):
+            dist += dl(waypoints[idx1].pose.pose.position, waypoints[i].pose.pose.position)
+            idx1 = i
+        return dist
 
 if __name__ == '__main__':
     try:

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -82,6 +82,9 @@ class TLDetector(object):
 
     def traffic_cb(self, msg):
 
+        if not self.waypoints_2d:
+            return
+
         red_wps_idx = []
         for l in msg.lights:
             if l.state == TrafficLight.RED:

--- a/ros/src/waypoint_updater/test_waypoint_updater.py
+++ b/ros/src/waypoint_updater/test_waypoint_updater.py
@@ -24,11 +24,11 @@ from std_msgs.msg import Int32
 
 N_WPS = 10
 
+
 class TestDeceleration(unittest.TestCase):
 
     def setUp(self):
         self.base_wps = Lane()
-
 
         self.wpu = WaypointUpdater(init_for_test=True)
         self.wpu.base_waypoints = self.base_wps

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -193,7 +193,7 @@ class WaypointUpdater(object):
         """
         if msg.data and msg.data >= 0:
             self.obstacle_wp_id = msg.data
-            rospy.logwarn('Obstacle received idx=%s', self.obstacle_wp_id)
+            rospy.logdebug('Obstacle received idx=%s', self.obstacle_wp_id)
         else:
             self.obstacle_wp_id = None
 


### PR DESCRIPTION
TLD just republishes now point from /vehicle/traffic_lights - not something that will work for prod
I've just updated code that @goforthecheez initially pushed - needed this part to test waypoint updater brake and acceleration algorithms fully at work

@goforthecheez I hope I have not conflicted with anything you were doing - based on updates on slack I thought I should be safe

- changed distance measurement logic
- updated logic for finding closest traffic light