### PR TITLE
Car stops at red lights before stop lines in the simulator.

### DIFF
--- a/ros/src/tl_detector/light_classification/tl_classifier.py
+++ b/ros/src/tl_detector/light_classification/tl_classifier.py
@@ -63,3 +63,4 @@ class TLClassifier(object):
         end = time.time()
         elapsed = end - start
         rospy.logwarn("Traffic light color is {} | Time elapsed: {} sec".format(color, elapsed))
+        return color

--- a/ros/src/tl_detector/light_classification/tl_classifier.py
+++ b/ros/src/tl_detector/light_classification/tl_classifier.py
@@ -1,6 +1,8 @@
 from styx_msgs.msg import TrafficLight
 import tensorflow as tf
 import numpy as np
+import time
+import rospy
 
 class TLClassifier(object):
     def __init__(self, is_site):
@@ -37,6 +39,7 @@ class TLClassifier(object):
             int: ID of traffic light color (specified in styx_msgs/TrafficLight)
 
         """
+        start = time.time()
         with self.graph.as_default():
             img_expand = np.expand_dims(image, axis=0)
             (boxes, scores, classes, num_detections) = self.sess.run(
@@ -46,14 +49,17 @@ class TLClassifier(object):
         boxes = np.squeeze(boxes)
         scores = np.squeeze(scores)
         classes = np.squeeze(classes).astype(np.int32)
-
         
         if scores[0] > self.threshold:
             if classes[0] == 1:
-                return TrafficLight.GREEN
+                color = TrafficLight.GREEN
             elif classes[0] == 2:
-                return TrafficLight.RED
+                color = TrafficLight.RED
             elif classes[0] == 3:
-                return TrafficLight.YELLOW
+                color = TrafficLight.YELLOW
+        else:
+            color = TrafficLight.UNKNOWN
 
-        return TrafficLight.UNKNOWN
+        end = time.time()
+        elapsed = end - start
+        rospy.logwarn("Traffic light color is {} | Time elapsed: {} sec".format(color, elapsed))

--- a/ros/src/tl_detector/light_classification/tl_classifier.py
+++ b/ros/src/tl_detector/light_classification/tl_classifier.py
@@ -64,3 +64,4 @@ class TLClassifier(object):
         elapsed = end - start
         rospy.logwarn("Traffic light color is {} | Time elapsed: {} sec".format(color, elapsed))
         return color
+

--- a/ros/src/tl_detector/test_tl_detector.py
+++ b/ros/src/tl_detector/test_tl_detector.py
@@ -15,24 +15,33 @@
 # python -m unittest discover -s src/tl_detector
 
 PKG = 'tl_detector'
+import copy
 import unittest
 
 from tl_detector import TLDetector
 from styx_msgs.msg import Lane, Waypoint
 from styx_msgs.msg import TrafficLightArray, TrafficLight
-from geometry_msgs.msg import Pose
+from geometry_msgs.msg import Pose, PoseStamped
+
+import numpy as np
 
 N_WPS = 10 # number of waypoints for test
 
 
 class TestTlDetector(unittest.TestCase):
 
+    @staticmethod
+    def _change_light_colors(tl_detector, new_colors):
+        for i, color in enumerate(new_colors):
+            tl_detector.lights[i].state = color
+
     def setUp(self):
         self.tld = TLDetector(is_testing=True)
 
         base_wps = Lane()
 
-        for pt in range(N_WPS):
+        # Waypoints are at (0.2, 0.2) increments.
+        for pt in np.arange(0, N_WPS, 0.2):
             wp = Waypoint()
             wp.pose.pose.position.x = pt
             wp.pose.pose.position.y = pt
@@ -41,18 +50,23 @@ class TestTlDetector(unittest.TestCase):
         self.tld.waypoints_cb(base_wps)
 
         lights = TrafficLightArray()
-        l_arr = [[1.0, 1.0, 0], [2.0, 2.2, 4], [3.0, 2.5, 1], [6.0, 6.0, 0] ]
+        l_arr = [[1.0, 1.0, 0], [2.0, 2.2, 2], [3.0, 2.5, 1], [6.0, 6.0, 0] ]
+        # Set stop lines (0.5, 0.5) in front of the traffic light.
+        # At runtime, stop_line_positions should be set using the ROS parameter server;
+        # so for testing, set values by reach into the tld object.
+        self.tld.stop_line_positions = []
         for l in l_arr:
             tl = TrafficLight()
             tl.state = l[2]
             tl.pose.pose.position.x = l[0]
             tl.pose.pose.position.y = l[1]
             lights.lights.append(tl)
+            self.tld.stop_line_positions.append([l[0] - 0.5, l[1] - 0.5])
         self.tld.traffic_cb(lights)
 
     def test_wp_cb(self):
-        self.assertEqual(len(self.tld.waypoints.waypoints), N_WPS)
-        self.assertEqual(len(self.tld.waypoints_2d), N_WPS)
+        self.assertEqual(len(self.tld.waypoints.waypoints), N_WPS * 5)
+        self.assertEqual(len(self.tld.waypoints_2d), N_WPS * 5)
         self.assertTrue(self.tld.waypoint_tree)
 
     def test_get_closest_wp(self):
@@ -62,69 +76,74 @@ class TestTlDetector(unittest.TestCase):
 
         idx = self.tld.get_closest_waypoint(p)
 
-        self.assertEqual(idx, 3)
+        self.assertEqual(idx, 15)
 
     def test_get_closest_wp_nearby(self):
         p = Pose()
         p.position.x = 3.0
-        p.position.y = 2.5
+        p.position.y = 2.9
 
         idx = self.tld.get_closest_waypoint(p)
 
-        self.assertEqual(idx, 3)
+        self.assertEqual(idx, 15)
 
     def test_get_closest_wp_nearby_above(self):
         p = Pose()
         p.position.x = 3.0
-        p.position.y = 3.5
+        p.position.y = 3.1
 
         idx = self.tld.get_closest_waypoint(p)
 
-        self.assertEqual(idx, 4)
+        self.assertEqual(idx, 16)
 
 # traffic_cb tests
-    def test_get_tl(self):
-        self.assertEqual(self.tld.lights_red_idxs, [1, 6]) #corresponding waypoint ids for each red traffic light
 
     def test_get_tl_no_red(self):
-        p = Pose()
-        p.position.x = 3.0
-        p.position.y = 3.0
+        p = PoseStamped()
+        p.pose.position.x = 3.0
+        p.pose.position.y = 3.0
+        self.tld.pose_cb(p)
 
-        self.tld.lights_red_idxs = []
-        # self.tld.lights = []
+        # Turn all the lights green.
+        TestTlDetector._change_light_colors(self.tld, [2] * 4)
 
-        idx = self.tld.get_closest_light(p)
+        light_wp, state = self.tld.process_traffic_lights()
 
-        self.assertEqual(idx, (-1, 4))
+        self.assertEqual(light_wp, 27)
+        self.assertEqual(state, 2)
 
-    def test_get_tl_wp_1ahead(self):
-        p = Pose()
-        p.position.x = 3.0
-        p.position.y = 3.0
+    def test_get_tl_wp_next_light_is_red(self):
+        p = PoseStamped()
+        p.pose.position.x = 3.0
+        p.pose.position.y = 3.0
+        self.tld.pose_cb(p)
 
-        idx = self.tld.get_closest_light(p)
+        light_wp, state = self.tld.process_traffic_lights()
 
-        self.assertEqual(idx, (6, 0))
+        self.assertEqual(light_wp, 27)
+        self.assertEqual(state, 0)
 
-    def test_get_tl_wp_2ahead(self):
-        p = Pose()
-        p.position.x = 0.0
-        p.position.y = 0.1
+    def test_get_tl_wp_next_light_is_red_but_passed_stop_line(self):
+        p = PoseStamped()
+        p.pose.position.x = 0.6
+        p.pose.position.y = 0.6
+        self.tld.pose_cb(p)
 
-        idx = self.tld.get_closest_light(p)
+        light_wp, state = self.tld.process_traffic_lights()
 
-        self.assertEqual(idx, (1, 0))
+        self.assertEqual(light_wp, 7)
+        self.assertEqual(state, 2)
 
     def test_get_tl_wp_loop(self):
-        p = Pose()
-        p.position.x = 10.0
-        p.position.y = 10.0
+        p = PoseStamped()
+        p.pose.position.x = 10.0
+        p.pose.position.y = 10.0
+        self.tld.pose_cb(p)
 
-        idx = self.tld.get_closest_light(p)
+        light_wp, state = self.tld.process_traffic_lights()
 
-        self.assertEqual(idx, (1, 0))
-
+        self.assertEqual(light_wp, 2)
+        self.assertEqual(state, 0)
 
 
 if __name__ == '__main__':

--- a/ros/src/tl_detector/test_tl_detector.py
+++ b/ros/src/tl_detector/test_tl_detector.py
@@ -28,7 +28,7 @@ N_WPS = 10 # number of waypoints for test
 class TestTlDetector(unittest.TestCase):
 
     def setUp(self):
-        self.tld = TLDetector(init_without_ros=True)
+        self.tld = TLDetector(is_testing=True)
 
         base_wps = Lane()
 

--- a/ros/src/tl_detector/test_tl_detector.py
+++ b/ros/src/tl_detector/test_tl_detector.py
@@ -84,14 +84,14 @@ class TestTlDetector(unittest.TestCase):
 
 # traffic_cb tests
     def test_get_tl(self):
-        self.assertEqual(self.tld.lights_red_2d, [1, 6]) #corresponding waypoint ids for each red traffic light
+        self.assertEqual(self.tld.lights_red_idxs, [1, 6]) #corresponding waypoint ids for each red traffic light
 
     def test_get_tl_no_red(self):
         p = Pose()
         p.position.x = 3.0
         p.position.y = 3.0
 
-        self.tld.lights_red_2d = []
+        self.tld.lights_red_idxs = []
         # self.tld.lights = []
 
         idx = self.tld.get_closest_light(p)

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -129,14 +129,13 @@ class TLDetector(object):
             int: ID of traffic light color (specified in styx_msgs/TrafficLight)
 
         """
-        # HACKHACKHACK: Read traffic light color from `/vehicle/traffic_lights` topic.
-        # NOTE: These values are only available within the simulator, not in real life.
+        # For testing, the lights array should be manually set and read from.
         if self.is_testing:
             return light.state
 
         if(not self.has_image):
             self.prev_light_loc = None
-            return False
+            return TrafficLight.UNKNOWN
 
         cv_image = self.bridge.imgmsg_to_cv2(self.camera_image, "bgr8")
 

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -154,17 +154,18 @@ class TLDetector(object):
         """
         # HACKHACKHACK: Read traffic light color from `/vehicle/traffic_lights` topic.
         # NOTE: These values are only available within the simulator, not in real life.
-        return light.state
+        # return light.state
 
-        #TODO Implement traffic light classifier and uncomment the original code below.
-        # if(not self.has_image):
-        #     self.prev_light_loc = None
-        #     return False
+        if(not self.has_image):
+            self.prev_light_loc = None
+            return False
 
-        # cv_image = self.bridge.imgmsg_to_cv2(self.camera_image, "bgr8")
+        cv_image = self.bridge.imgmsg_to_cv2(self.camera_image, "bgr8")
 
-        # #Get classification
-        # return self.light_classifier.get_classification(cv_image)
+        # Get classification
+        classification = self.light_classifier.get_classification(cv_image)
+        rospy.logwarn("Traffic light color={}".format(classification))
+        return classification
 
     def process_traffic_lights(self):
         """Finds closest visible traffic light, if one exists, and determines its
@@ -181,18 +182,18 @@ class TLDetector(object):
         if(self.pose):
             car_wp_idx = self.get_closest_waypoint(self.pose.pose)
 
-            for l_idx in self.lights_red_idxs:
+            for l_idx, _ in enumerate(self.lights):
                 stop_x, stop_y = self.stop_line_positions[l_idx]
                 # Car should stop *before* the stop line.
                 stop_line_wp_idx = (self.get_closest_waypoint_xy(stop_x, stop_y) - 1) % len(self.waypoints.waypoints)
                 if stop_line_wp_idx > car_wp_idx:
-                    return stop_line_wp_idx, TrafficLight.RED
+                    return stop_line_wp_idx, self.get_light_state(self.lights[l_idx])  # TODO(adelinew): Delete arg.
 
-            if len(self.lights_red_idxs):  # waypoint is further than last light - let's loop
+            if len(self.lights):  # waypoint is further than last light - let's loop
                 stop_x, stop_y = self.stop_line_positions[0]
                 # Car should stop *before* the stop line.
                 stop_line_wp_idx = (self.get_closest_waypoint_xy(stop_x, stop_y) - 1) % len(self.waypoints.waypoints)
-                return stop_line_wp_idx, TrafficLight.RED
+                return stop_line_wp_idx, self.get_light_state(self.lights[0])  # TODO(adelinew): Delete arg.
 
         return -1, TrafficLight.UNKNOWN
 

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -94,7 +94,11 @@ class TLDetector(object):
         """
         if not self.waypoints_2d or not self.waypoint_tree:
             return
-        
+
+        t = rospy.get_rostime()
+        if int(t.nsecs * 1e-8) % 5 != 0:
+            return
+
         self.has_image = True
         self.camera_image = msg
         stop_line_wp, state = self.process_traffic_lights()

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -89,7 +89,8 @@ class TLDetector(object):
     def traffic_cb(self, msg):
         self.lights = msg.lights
 
-        if not self.is_testing:
+        # TODO(adelinew): Restore this to if *not* self.is_testing.
+        if self.is_testing:
             if not self.waypoints_2d or not self.waypoint_tree:
                 return
 

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -34,7 +34,7 @@ class TLDetector(object):
         self.camera_image = None
 
         self.lights = []
-        self.lights_red_2d = [] # [waypoint_idx, ... ] array of waypoints associated with the red light
+        self.lights_red_idxs = [] # [waypoint_idx, ... ] array of waypoints associated with the red light
 
 
         self.bridge = CvBridge()
@@ -96,7 +96,7 @@ class TLDetector(object):
                     l_wp_idx = self.get_closest_waypoint_xy(l.pose.pose.position.x, l.pose.pose.position.y)
                     red_wps_idx.append(l_wp_idx)
             red_wps_idx.sort()
-            self.lights_red_2d = red_wps_idx
+            self.lights_red_idxs = red_wps_idx
 
             # for testing without proper detector TODO: remove
             # rospy.logwarn("Update TL point 101 wps={}, pose={}".format(self.waypoints is not None, self.pose is not None))
@@ -199,12 +199,12 @@ class TLDetector(object):
         y = pose.position.y
         wp_idx = self.get_closest_waypoint_xy(x, y)
 
-        for l_idx in self.lights_red_2d:
+        for l_idx in self.lights_red_idxs:
             if l_idx > wp_idx:
                 return l_idx, TrafficLight.RED
 
-        if len(self.lights_red_2d):  # waypoint is further than last light - let's loop
-            return self.lights_red_2d[0], TrafficLight.RED
+        if len(self.lights_red_idxs):  # waypoint is further than last light - let's loop
+            return self.lights_red_idxs[0], TrafficLight.RED
         else:
             return -1, TrafficLight.UNKNOWN
 

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -129,7 +129,7 @@ class TLDetector(object):
             int: ID of traffic light color (specified in styx_msgs/TrafficLight)
 
         """
-        # For testing, the lights array should be manually set and read from.
+        # In tests, manually set the lights array and read state from it.
         if self.is_testing:
             return light.state
 

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -52,7 +52,7 @@ class WaypointUpdater(object):
             self.periodically_publish_waypoints()
 
     def periodically_publish_waypoints(self):
-        rate = rospy.Rate(50)
+        rate = rospy.Rate(25)
         while not rospy.is_shutdown():
             if self.pose and self.waypoint_tree: #tree is constructed later than base_waypoints are set, prevents races
                 # Get closest waypoint


### PR DESCRIPTION
This now generates the right behavior, but it needs to be cleaned up a lot. Maybe it's useful for tuning DBW? I'm in any case too tired to look into this more for tonight, but I'll continue tomorrow.

Main issues:

1. It looks like the needs of testing DBW and the WPU started to dominate what was going on in tl_detector.py. The main logic at the moment runs through lights_red_idxs (formerly lights_red_2d), which doesn't make sense for using the TL classifier, which is a big model and anyway the car's camera can't see all the traffic lights at the same time. I think this structure can be deleted and the unit tests rewritten to refer to just the self.lights array and the stop_line_positions array.

2. The testing and real parts of the code are at the moment not clearly divided up. In particular, commit 9d0216b should be undone, and the logic in process_traffic_lights() needs to be clarified.

3. test_tl_detector.py no longer passes.