### PR TITLE
Add logic to not run TF classifier if traffic light is too far away. Also shorten camera info publisher queue length to 1.

### DIFF
--- a/ros/src/camera_info_publisher/yaml_to_camera_info_publisher.py
+++ b/ros/src/camera_info_publisher/yaml_to_camera_info_publisher.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
 
     # Initialize publisher node
     rospy.init_node("camera_info_publisher", anonymous=True)
-    publisher = rospy.Publisher("camera_info", CameraInfo, queue_size=10)
+    publisher = rospy.Publisher("camera_info", CameraInfo, queue_size=1)
     rate = rospy.Rate(10)
 
     # Run publisher

--- a/ros/src/tl_detector/light_classification/tl_classifier.py
+++ b/ros/src/tl_detector/light_classification/tl_classifier.py
@@ -13,7 +13,7 @@ class TLClassifier(object):
             PATH_TO_GRAPH = r'light_classification/models/ssd_i_coco/sim/frozen_inference_graph.pb'
 
         self.graph = tf.Graph()
-        self.threshold = .5
+        self.threshold = 0.15
 
         with self.graph.as_default():
             od_graph_def = tf.GraphDef()
@@ -49,16 +49,25 @@ class TLClassifier(object):
         boxes = np.squeeze(boxes)
         scores = np.squeeze(scores)
         classes = np.squeeze(classes).astype(np.int32)
-        
-        if scores[0] > self.threshold:
-            if classes[0] == 1:
-                color = TrafficLight.GREEN
-            elif classes[0] == 2:
-                color = TrafficLight.RED
-            elif classes[0] == 3:
-                color = TrafficLight.YELLOW
-        else:
+
+        #rospy.logwarn("classes: {}".format(' '.join([str(c) for c in classes])))
+        #rospy.logwarn("scores: {}".format(' '.join([str(s) for s in scores])))
+
+        colors = [TrafficLight.GREEN, TrafficLight.RED, TrafficLight.YELLOW]
+        counts = [0] * 3
+        for i, s in enumerate(scores):
+            if s > self.threshold:
+                if classes[i] == 1:  # green
+                    counts[0] = counts[0] + 1
+                elif classes[i] == 2:  # red
+                    counts[1] = counts[1] + 1
+                elif classes[i] == 3:  # yellow
+                    counts[2] = counts[2] + 1
+        max_idx = np.argmax(counts)
+        if counts[max_idx] == 0:
             color = TrafficLight.UNKNOWN
+        else:
+            color = colors[max_idx]
 
         elapsed = time.time() - start
         rospy.logwarn("Traffic light color is {} | Time elapsed: {} sec".format(color, elapsed))

--- a/ros/src/tl_detector/light_classification/tl_classifier.py
+++ b/ros/src/tl_detector/light_classification/tl_classifier.py
@@ -60,8 +60,7 @@ class TLClassifier(object):
         else:
             color = TrafficLight.UNKNOWN
 
-        end = time.time()
-        elapsed = end - start
+        elapsed = time.time() - start
         rospy.logwarn("Traffic light color is {} | Time elapsed: {} sec".format(color, elapsed))
         return color
 

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -18,7 +18,7 @@ import numpy as np
 
 STATE_COUNT_THRESHOLD = 3
 SKIPPING_DURATION = 0.5 # time in seconds to wait until next camera image will be processed
-MAX_WP_DISTANCE_TO_CLASSIFY_TL = 20
+MAX_WP_DISTANCE_TO_CLASSIFY_TL = 100
 
 class TLDetector(object):
 
@@ -192,7 +192,7 @@ class TLDetector(object):
                     if (stop_line_wp_idx - car_wp_idx) < MAX_WP_DISTANCE_TO_CLASSIFY_TL:
                         return stop_line_wp_idx, self.get_light_state(self.lights[i])
                     else:
-                        rospy.logwarn("Request to process traffic light, but it is too far.")
+                        #rospy.logwarn("Request to process traffic light, but it is too far.")
                         return -1, TrafficLight.UNKNOWN
 
             if len(self.lights):  # waypoint is further than last light - let's loop
@@ -202,7 +202,7 @@ class TLDetector(object):
                 if (stop_line_wp_idx - car_wp_idx) % len(self.waypoints.waypoints) < MAX_WP_DISTANCE_TO_CLASSIFY_TL:
                     return stop_line_wp_idx, self.get_light_state(self.lights[0])
                 else:
-                    rospy.logwarn("Request to process traffic light, but it is too far.")
+                    #rospy.logwarn("Request to process traffic light, but it is too far.")
                     return -1, TrafficLight.UNKNOWN
 
         return -1, TrafficLight.UNKNOWN

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import time
 import math
 import sys
 import rospy
@@ -17,6 +18,7 @@ import numpy as np
 
 STATE_COUNT_THRESHOLD = 3
 SKIPPING_DURATION = 0.5 # time in seconds to wait until next camera image will be processed
+MAX_WP_DISTANCE_TO_CLASSIFY_TL = 20
 
 class TLDetector(object):
 
@@ -115,8 +117,8 @@ class TLDetector(object):
                 self.timestamp_before = timestamp_now
                 self.skipping_duration += rospy.Duration(SKIPPING_DURATION) - time_elapsed
 
-        self.has_image = True
         self.camera_image = msg
+        self.has_image = True
         stop_line_wp, state = self.process_traffic_lights()
         # if state == 0:
         # rospy.logwarn("Traffic light: pt=%s, state=%s", stop_line_wp, state)
@@ -153,14 +155,16 @@ class TLDetector(object):
         if self.is_testing:
             return light.state
 
-        if(not self.has_image):
-            self.prev_light_loc = None
+        if not self.has_image:
+            #self.prev_light_loc = None
+            rospy.logwarn("Camera not ready yet...")
             return TrafficLight.UNKNOWN
 
         cv_image = self.bridge.imgmsg_to_cv2(self.camera_image, "bgr8")
 
         # Get classification
         classification = self.light_classifier.get_classification(cv_image)
+        self.has_image = False    # Reset; so we only classify new images.
         return classification
 
     def process_traffic_lights(self):
@@ -185,13 +189,21 @@ class TLDetector(object):
                 # self.lights is in order. Return as soon as we see the first traffic
                 # light (stop line) past the car's position.
                 if stop_line_wp_idx > car_wp_idx:
-                    return stop_line_wp_idx, self.get_light_state(self.lights[i])
+                    if (stop_line_wp_idx - car_wp_idx) < MAX_WP_DISTANCE_TO_CLASSIFY_TL:
+                        return stop_line_wp_idx, self.get_light_state(self.lights[i])
+                    else:
+                        rospy.logwarn("Request to process traffic light, but it is too far.")
+                        return -1, TrafficLight.UNKNOWN
 
             if len(self.lights):  # waypoint is further than last light - let's loop
                 stop_x, stop_y = self.stop_line_positions[0]
                 # Car should stop *before* the stop line.
                 stop_line_wp_idx = (self.get_closest_waypoint_xy(stop_x, stop_y) - 1) % len(self.waypoints.waypoints)
-                return stop_line_wp_idx, self.get_light_state(self.lights[0])
+                if (stop_line_wp_idx - car_wp_idx) % len(self.waypoints.waypoints) < MAX_WP_DISTANCE_TO_CLASSIFY_TL:
+                    return stop_line_wp_idx, self.get_light_state(self.lights[0])
+                else:
+                    rospy.logwarn("Request to process traffic light, but it is too far.")
+                    return -1, TrafficLight.UNKNOWN
 
         return -1, TrafficLight.UNKNOWN
 

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -16,7 +16,7 @@ import yaml
 from scipy.spatial import KDTree
 import numpy as np
 
-STATE_COUNT_THRESHOLD = 3
+STATE_COUNT_THRESHOLD = 2
 SKIPPING_DURATION = 0.5 # time in seconds to wait until next camera image will be processed
 MAX_WP_DISTANCE_TO_CLASSIFY_TL = 100
 

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -26,6 +26,7 @@ TODO (for Yousuf and Aaron): Stopline location for each traffic light.
 '''
 
 LOOKAHEAD_WPS = 70  # Number of waypoints we will publish. You can change this number
+NEXT_WP_AHEAD = 5   # Number of waypoints we add to the closest waypoint
 DECEL_AT_STOP = -0.3 # how fast shall we decelerate at the last point, m/s
 DECEL_AT_START = -0.05
 
@@ -99,7 +100,7 @@ class WaypointUpdater(object):
         if self.obstacle_wp_id > closest_idx:
             last_idx = min(closest_idx + LOOKAHEAD_WPS, self.obstacle_wp_id) #TODO fix for circle case
 
-        lane.waypoints = self.base_waypoints.waypoints[closest_idx:last_idx]
+        lane.waypoints = self.base_waypoints.waypoints[closest_idx+NEXT_WP_AHEAD:last_idx+NEXT_WP_AHEAD]
 
         if closest_idx <= self.obstacle_wp_id <= last_idx:
             lane.waypoints = self.decelerate_waypoints(lane.waypoints)

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -54,7 +54,7 @@ class WaypointUpdater(object):
             self.periodically_publish_waypoints()
 
     def periodically_publish_waypoints(self):
-        rate = rospy.Rate(25)
+        rate = rospy.Rate(20)
         while not rospy.is_shutdown():
             if self.pose and self.waypoint_tree: #tree is constructed later than base_waypoints are set, prevents races
                 # Get closest waypoint


### PR DESCRIPTION
I.e., if we don't process an image in time, drop it and use the next available.