### PR TITLE
Fix encoding, b/c OpenCV defies convention.

### DIFF
--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -160,7 +160,7 @@ class TLDetector(object):
             rospy.logwarn("Camera not ready yet...")
             return TrafficLight.UNKNOWN
 
-        cv_image = self.bridge.imgmsg_to_cv2(self.camera_image, "bgr8")
+        cv_image = self.bridge.imgmsg_to_cv2(self.camera_image, "rgb8")
 
         # Get classification
         classification = self.light_classifier.get_classification(cv_image)


### PR DESCRIPTION
Hiep's Jupyter notebook (and presumably the train.py script) assume RGB image encodings, but the encoding used on the car was the normal OpenCV BGR. With this, the classifications are perfectly steady.